### PR TITLE
chore: docker-compose is eol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-EXEC_APP := docker-compose exec -T app
+EXEC_APP := docker compose exec -T app
 # INTERFACES = $(shell $(EXEC_APP) find -name "interface.go" )
 GO_VER = 1.20
 
@@ -11,11 +11,11 @@ lint:
 	@$(EXEC_APP) golangci-lint run --fix --timeout 3m
 
 up:
-	@docker-compose up -d
+	@docker compose up -d
 	@$(EXEC_APP) go mod tidy -go=${GO_VER}
 
 down:
-	@docker-compose down
+	@docker compose down
 
 # gen-mock:
 # 	@$(foreach src,$(INTERFACES), $(EXEC_APP) sh tools/mockgen/codegen.sh ${src} || exit;)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Goで単体テストコードを書くためのチュートリアルです<br>
         └── db          : chapter4のみ。DBアクセス処理
 ```
 # 動作環境
-- `Docker Desktop`等の`docker`及び`docker-compose`が動作する環境
+- `Docker Desktop`等の`docker`及び`docker compose`が動作する環境
 - 以下コマンドが必要です
   - `git`
   - `make`（Windowsをお使いの方）
@@ -37,9 +37,9 @@ Goで単体テストコードを書くためのチュートリアルです<br>
 - テスト実施方法
   - `$ make gotest`を実行してください
   - パッケージ単位や関数単位でテストを実行したい場合
-    - パッケージ単位：`$ docker-compose exec -T <サービス名(※)> go test -v <テスト対象のパッケージまでのパス>`
+    - パッケージ単位：`$ docker compose exec -T <サービス名(※)> go test -v <テスト対象のパッケージまでのパス>`
     - 関数単位：上記パッケージ単位までのコマンドに `-run <関数名>` を追加してください
-      - ※サービス名は`docker-compose.yml`の`services`に記載されているものです。当チュートリアルの場合は`app`になります
+      - ※サービス名は`docker compose.yml`の`services`に記載されているものです。当チュートリアルの場合は`app`になります
 
 ## テストの記述例
 ```go

--- a/chapters/chapter6/README.md
+++ b/chapters/chapter6/README.md
@@ -24,7 +24,7 @@ func TestSample(t *testing.T) { // トップテスト関数
 - 以下コマンドでテストを実行してください
 
 ```
-$ docker-compose exec app go test -v -count=1 github.com/dip-dev/go-test-tutorial/chapters/chapter6 -run TestPrintString
+$ docker compose exec app go test -v -count=1 github.com/dip-dev/go-test-tutorial/chapters/chapter6 -run TestPrintString
 ```
 
 テストの完了に3秒ほど掛かったはずです
@@ -104,7 +104,7 @@ ok  	github.com/dip-dev/go-test-tutorial/chapters/chapter6	1.006s
 ### 3. トップテスト関数を並列実行してみよう
 - 以下コマンドでテストを実行してください
 ```
-$ docker-compose exec app go test -v -count=1 github.com/dip-dev/go-test-tutorial/chapters/chapter6
+$ docker compose exec app go test -v -count=1 github.com/dip-dev/go-test-tutorial/chapters/chapter6
 ```
 
 実行に2秒ほど掛かったかと思います<br>
@@ -121,7 +121,7 @@ $ docker-compose exec app go test -v -count=1 github.com/dip-dev/go-test-tutoria
 - 以下コマンドでテストを実行してください
   - トップテスト関数が2つでそれぞれサブテストが3つ起動するので`-parallel=6`を指定しています
 ```
-$ docker-compose exec app go test -v -parallel=6 -count=1 github.com/dip-dev/go-test-tutorial/chapters/chapter6
+$ docker compose exec app go test -v -parallel=6 -count=1 github.com/dip-dev/go-test-tutorial/chapters/chapter6
 ```
 
 2つのトップテスト関数の実行が1秒ほどで完了したかと思います

--- a/chapters/chapter7/README.md
+++ b/chapters/chapter7/README.md
@@ -11,7 +11,7 @@ func deleteTextFile(t *testing.T, target string) {
 ```
 - 以下コマンドでテストを実行してください
 ```
-$ docker-compose exec app go test -count=1 github.com/dip-dev/go-test-tutorial/chapters/chapter7
+$ docker compose exec app go test -count=1 github.com/dip-dev/go-test-tutorial/chapters/chapter7
 ```
 
 以下のような結果になったかと思います


### PR DESCRIPTION
Since Compose V1 is already EOL, V2 commands are recommended.